### PR TITLE
Rework/simplify webpack.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "npm run dev",
-    "dev": "./node_modules/.bin/webpack-dev-server --progress --profile --colors --hot",
+    "dev": "./node_modules/.bin/webpack-dev-server --progress --profile --colors --hot --inline --no-info --content-base ./public",
     "build": "./node_modules/.bin/webpack --progress --profile --colors",
     "lint": "./node_modules/.bin/eslint --ext .js --ext .jsx src tests",
     "test": "./node_modules/.bin/mocha 'tests/**/*.js' --compilers js:babel-core/register --recursive --require ./tests/setup.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,47 +1,19 @@
-'use strict';
-const path = require('path');
-const webpack = require('webpack');
+var webpack = require('webpack');
 
 module.exports = {
-  entry: [
-    'webpack-dev-server/client?http://127.0.0.1:8080',
-    'webpack/hot/only-dev-server',
-    './src/App.js'
-  ],
+  entry: "./src/App.js",
   output: {
-    path: path.join(__dirname, 'public'),
-    filename: 'app.js'
+    path: __dirname + '/public',
+    filename: 'app.js',
   },
   module: {
     loaders: [
       {
-        test: /\.js(x?)$/,
-        exclude: /(node_modules|bower_components)/,
+        test: /\.js$/,
+        exclude: /node_modules/,
         loaders: ['react-hot', 'babel'],
-      },
-      {
-        test: /\.css$/,
-        loader: 'style-loader!css-loader'
-      },
-      {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        loader: "url?limit=10000&mimetype=image/svg+xml"
-      },
-      {
-        test: /\.jpg/,
-        loader: "url-loader?limit=10000&mimetype=image/jpg"
-      },
-      {
-        test: /\.png/,
-        loader: "url-loader?limit=10000&mimetype=image/png"
       }
     ]
-  },
-  devServer: {
-    contentBase: "./public",
-    noInfo: true,
-    hot: true,
-    inline: true
   },
   plugins: [
     new webpack.NoErrorsPlugin()


### PR DESCRIPTION
- Removes a lot of confusing cruft, leaving only the core bits
- Moves dev-server config to CLI flags in package.json
